### PR TITLE
AddUniqueKeyToUsername migration remove_index fix

### DIFF
--- a/db/migrate/20130826101227_add_unique_key_to_username.rb
+++ b/db/migrate/20130826101227_add_unique_key_to_username.rb
@@ -1,9 +1,14 @@
 class AddUniqueKeyToUsername < ActiveRecord::Migration
   def self.up
-    remove_index :users, :name => :index_users_on_username
+    # ignore errors in case index was not there (it might happen)
+    begin
+      remove_index :users, :name => :index_users_on_username
+    rescue
+      nil
+    end
     add_index :users, :username, :unique => true
   end
-  
+
   def self.down
     remove_index :users, :name => :index_users_on_username
     add_index :users, :username


### PR DESCRIPTION
insert instruction in a begin/rescue block to avoid aborting the migrations in case the index is not found.
